### PR TITLE
Adding build script to create php-gameboy.phar

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,76 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Finder\Finder;
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+
+$rootDir = __DIR__ . '/..';
+
+$filename = 'php-gameboy.phar';
+$filePath = $rootDir . '/bin/' . $filename;
+$stub = <<<STUB
+#!/usr/bin/env php
+<?php
+
+Phar::mapPhar("php-gameboy.phar");
+
+require_once("phar://php-gameboy.phar/php-terminal-gameboy-emulator/boot.php");
+
+__HALT_COMPILER();
+
+STUB;
+
+if (file_exists($filePath)) {
+    unlink($filePath);
+}
+
+$finderSort = function ($a, $b) {
+    return strcmp(strtr($a->getRealPath(), '\\', '/'), strtr($b->getRealPath(), '\\', '/'));
+};
+
+function addFile($phar, $file)
+{
+    $path = strtr(str_replace(dirname(dirname(__DIR__)).DIRECTORY_SEPARATOR, '', $file->getRealPath()), '\\', '/');
+
+    $content = file_get_contents($file);
+
+    $phar->addFromString($path, $content);
+}
+
+$phar = new Phar(
+    $filePath,
+    FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::KEY_AS_FILENAME,
+    $filename
+);
+$phar->setSignatureAlgorithm(\Phar::SHA1);
+$phar->startBuffering();
+
+$finder = new Finder();
+$finder->files()
+    ->ignoreVCS(true)
+    ->name('*.php')
+    ->exclude('bin')
+    ->exclude('.gitignore')
+    ->exclude('.travis.yml')
+    ->exclude('README.md')
+    ->exclude('build.xml')
+    ->exclude('cache.properties')
+    ->exclude('composer.json')
+    ->exclude('composer.lock')
+    ->exclude('docker-php-7')
+    ->exclude('phpcs.xml')
+    ->exclude('.git')
+    ->in($rootDir)
+    ->sort($finderSort)
+;
+
+foreach ($finder as $file) {
+    addFile($phar, $file);
+}
+
+$phar->setStub($stub);
+
+$phar->stopBuffering();
+
+chmod($filePath, 0775);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "bin": ["bin/php-gameboy"],
     "require-dev": {
-        "squizlabs/php_codesniffer": "2.0.*@dev"
+        "squizlabs/php_codesniffer": "2.0.*@dev",
+        "symfony/finder" : "*"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6f5eed549688ca9a4eb124eae054ffce",
-    "content-hash": "ccc583d4e7fb658a3842017f2fc17e17",
+    "hash": "6d7bf9f4d4a59581c0bdf16ecfa1e8b9",
+    "content-hash": "9d0ca641c2c0029c4ebdde83b2a8a6db",
     "packages": [
         {
             "name": "whatthejeff/drawille",
@@ -133,6 +133,55 @@
                 "standards"
             ],
             "time": "2014-12-05 00:14:12"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/623bda0abd9aa29e529c8e9c08b3b84171914723",
+                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-01-27 05:14:46"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
This PR has #26 as dependency, not needing this part:

``` php
foreach (['../../autoload.php', '../vendor/autoload.php', 'vendor/autoload.php'] as $autoload) {
    $autoload = __DIR__.'/'.$autoload;
    if (file_exists($autoload)) {
        require $autoload;
        break;
    }
}
unset($autoload);
```

is just necessary:

``` php
require_once __DIR__.'/vendor/autoload.php';
```

so, building the php-gameboy.phar without #26 PR you'll have the 'roms/' directory as dependency.

**Creating Phar**

You'll need change the php.ini `phar.readonly` option to Off, run the composer update, and then run the `bin/build`
