### PR TITLE
Make Core Smaller

### DIFF
--- a/src/Config/TimingTrait.php
+++ b/src/Config/TimingTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GameBoy\Config;
+
+trait timingTrait
+{
+
+    //
+    //Timing Variables
+    //
+
+    //Used to sample the audio system every x CPU instructions.
+    public $audioTicks = 0;
+
+    //Times for how many instructions to execute before ending the loop.
+    public $emulatorTicks = 0;
+
+    // DIV Ticks Counter (Invisible lower 8-bit)
+    public $DIVTicks = 14;
+
+    // ScanLine Counter
+    public $LCDTicks = 15;
+
+    // Timer Ticks Count
+    public $timerTicks = 0;
+
+    // Timer Max Ticks
+    public $TACClocker = 256;
+
+    //Are the interrupts on queue to be enabled?
+    public $untilEnable = 0;
+
+    //The last time we iterated the main loop.
+    public $lastIteration = 0;
+}

--- a/src/Core.php
+++ b/src/Core.php
@@ -191,30 +191,8 @@ class Core
     //Timing Variables
     //
 
-    //Used to sample the audio system every x CPU instructions.
-    public $audioTicks = 0;
-
-    //Times for how many instructions to execute before ending the loop.
-    public $emulatorTicks = 0;
-
-    // DIV Ticks Counter (Invisible lower 8-bit)
-    public $DIVTicks = 14;
-
-    // ScanLine Counter
-    public $LCDTicks = 15;
-
-    // Timer Ticks Count
-    public $timerTicks = 0;
-
-    // Timer Max Ticks
-    public $TACClocker = 256;
-
-    //Are the interrupts on queue to be enabled?
-    public $untilEnable = 0;
-
-    //The last time we iterated the main loop.
-    public $lastIteration = 0;
-
+    use Config\TimingTrait;
+    
     //
     //ROM Cartridge Components:
     //


### PR DESCRIPTION
Sticking Timing Vars in Timing Trait. If you think this is a good idea, I can obviously continue this and repeat this for the first (approx) 300 lines of variables that are set at the top of the Core class.

The Config DIR in my mind is a little easier to navigate, and should make things easier to find.

Peace,

Clint!